### PR TITLE
Add viewport meta tag to novel page

### DIFF
--- a/novel/index.html
+++ b/novel/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
  <head>
-  <meta charset="utf-8"/>
+ <meta charset="utf-8"/>
+ <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>
    Available Novels
   </title>


### PR DESCRIPTION
### Motivation
- Ensure proper mobile scaling for the novel listing page by adding a viewport meta tag to the page head.
- Improve rendering on small screens for `novel/index.html` without changing functionality.

### Description
- Inserted `<meta name="viewport" content="width=device-width, initial-scale=1">` immediately after the charset declaration in the `<head>` of `novel/index.html`.
- No other markup or styling changes were made to the page.

### Testing
- No automated tests were run for this static HTML change.
- No automated test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e304a1b0083269e05571fa05c5fd2)