### PR TITLE
Improve mobile nav link contrast

### DIFF
--- a/css/style_novel.css
+++ b/css/style_novel.css
@@ -86,9 +86,21 @@ h1, h2, h3 {
     position: absolute;
     top: 60px;
     right: 0;
-    background-color: white;
-    border: 1px solid #ccc;
+    background-color: #1f1f1f;
+    border: 1px solid #111;
     width: 200px;
+  }
+
+  .nav-links a {
+    color: #f5f5f5;
+  }
+
+  .nav-links a:hover,
+  .nav-links a:focus,
+  .nav-links a:focus-visible {
+    color: #f0a500;
+    background-color: #2c2c2c;
+    outline: none;
   }
 
   .nav-links.active {


### PR DESCRIPTION
### Motivation
- Improve readability of the mobile navigation dropdown under `@media (max-width: 768px)` by increasing text/background contrast.
- Provide a clear interactive state for links so hover and focus are easily visible on small screens.
- Ensure the mobile nav meets basic accessibility/contrast expectations for dark backgrounds.

### Description
- Updated `css/style_novel.css` inside the `@media (max-width: 768px)` block to change `.nav-links` background from white to `#1f1f1f` and its border to `#111`.
- Added link color rules ` .nav-links a { color: #f5f5f5; }` to ensure readable text on the dark background.
- Implemented hover and focus states for mobile nav links with `color: #f0a500` and `background-color: #2c2c2c` and removed default outlines for a consistent visual treatment.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` and successfully served the site for visual verification.
- Ran a Playwright script that loaded `http://127.0.0.1:8000/novel/index.html` at a 375x800 viewport, toggled the mobile menu, and produced a screenshot of the updated mobile nav.
- The Playwright visual check completed successfully and produced the screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e31bd86788326ac070e849b53926a)