### PR TITLE
Add :focus-visible styles for novel navigation and controls

### DIFF
--- a/css/style_novel.css
+++ b/css/style_novel.css
@@ -70,12 +70,23 @@ h1, h2, h3 {
   color: #f0a500; /* Add a hover effect for better interactivity */
 }
 
+.nav a:focus-visible {
+  outline: 2px solid #f0a500;
+  outline-offset: 3px;
+}
+
 .menu-toggle {
   display: none;
   font-size: 24px;
   background: none;
   border: none;
   cursor: pointer;
+}
+
+.menu-toggle:focus-visible {
+  outline: 2px solid #f0a500;
+  outline-offset: 4px;
+  border-radius: 4px;
 }
 
 /* Responsive styles for smaller screens */
@@ -221,6 +232,12 @@ h1, h2, h3 {
   color: #fff;
 }
 
+.novel-list a:focus-visible {
+  outline: 2px solid #f0a500;
+  outline-offset: 4px;
+  border-radius: 6px;
+}
+
 /* Section headings */
 .complete-novels h4,
 .incomplete-novels h4 {
@@ -244,6 +261,13 @@ h1, h2, h3 {
 
 .status.incomplete {
   background-color: red;
+}
+
+.status:focus-visible,
+button:focus-visible {
+  outline: 2px solid #f0a500;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(240, 165, 0, 0.35);
 }
 
 .footer {


### PR DESCRIPTION
### Motivation
- Improve keyboard accessibility so focusable elements in the novel UI are clearly visible to keyboard users.
- Keep focus styling consistent with the site's existing accent color and theme.

### Description
- Added `:focus-visible` rules for `.nav a` to show an accent outline and offset to highlight focused navigation links.
- Added `:focus-visible` rules for `.menu-toggle` and `.novel-list a` with matching outline, offset, and `border-radius` for visual consistency.
- Added `:focus-visible` styles for `.status` badges and `button` elements including an outline and subtle `box-shadow` ring.
- Changes were made in `css/style_novel.css` to implement the above selectors and styling.

### Testing
- Started a local server with `python -m http.server 8000` and the server ran successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:8000/novel/index.html`, sent keyboard navigation (`Tab`), and captured `artifacts/novel-focus-visible.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e31d1623083269708ba9d2e94c79e)