### PR TITLE
Make novel list images responsive and center card content

### DIFF
--- a/css/style_novel.css
+++ b/css/style_novel.css
@@ -197,7 +197,8 @@ h1, h2, h3 {
 }
 
 .novel-list img {
-  width: 300px; /* Set a fixed width for the images */
+  width: 100%;
+  max-width: 240px;
   height: auto; /* Maintain aspect ratio */
   margin: 0 auto; /* Center the image within the list item */
   display: block;
@@ -212,7 +213,9 @@ h1, h2, h3 {
 .novel-list a {
   text-decoration: none;
   color: #333;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   padding: 1rem;
 }
 


### PR DESCRIPTION
### Motivation
- Replace a fixed image width to allow covers to scale and fit within the novel cards on smaller viewports.
- Ensure the image is centered within the card and card content aligns nicely for balanced mobile layouts.
- Keep the card visual proportions consistent with existing `minmax` grid sizing so cards remain balanced across breakpoints.

### Description
- Updated `css/style_novel.css` to change `.novel-list img` from a fixed `width: 300px` to `width: 100%` with `max-width: 240px` to make images responsive.
- Converted `.novel-list a` from `display: block` to a flex column with `display: flex`, `flex-direction: column`, and `align-items: center` to center card contents.
- Left image `height: auto` and existing inline `aspect-ratio`/`object-fit` intact so aspect ratios are preserved.
- Minor whitespace/newline normalization at end of file.

### Testing
- Started a local dev server and attempted automated visual checks with Playwright, but the Playwright run crashed (headless Chromium SIGSEGV) so screenshots could not be captured.
- No other automated tests were executed in this environment.
- The CSS file was staged and committed locally after the changes succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e31d4b9d8832687cd8993d11445fe)