### PR TITLE
Use responsive picture markup for "Only a Fan Dream" cover

### DIFF
--- a/novel/index.html
+++ b/novel/index.html
@@ -210,13 +210,20 @@
       </span>
      </a>
     </li>
-         <li>
-        <a href="/novel/only-a-fan-dream/">
-          <img src="/images/only-a-fan-dream-cover.png" alt="Only a Fan Dream">
-          <h4>Only a Fan Dream</h4>
-          <span class="status incomplete">Incomplete</span>
-        </a>
-      </li>
+    <li>
+     <a href="/novel/only-a-fan-dream/">
+      <picture>
+       <source srcset="/images/only-a-fan-dream-cover-320.webp 320w, /images/only-a-fan-dream-cover-640.webp 640w, /images/only-a-fan-dream-cover-960.webp 960w" type="image/webp"/>
+       <img alt="Only a Fan Dream" decoding="async" height="960" loading="lazy" sizes="(max-width: 480px) 45vw, (max-width: 900px) 30vw, 240px" src="/images/only-a-fan-dream-cover-640.jpg" srcset="/images/only-a-fan-dream-cover-320.jpg 320w, /images/only-a-fan-dream-cover-640.jpg 640w, /images/only-a-fan-dream-cover-960.jpg 960w" style="aspect-ratio: 2 / 3; object-fit: cover; border-radius: 8px;" width="640"/>
+      </picture>
+      <h4>
+       Only a Fan Dream
+      </h4>
+      <span class="status incomplete">
+       Incomplete
+      </span>
+     </a>
+    </li>
 </ul>
   </main>
   <footer class="footer">


### PR DESCRIPTION
### Motivation
- Make the "Only a Fan Dream" listing consistent with other novels by using responsive image markup.
- Improve performance and responsiveness by providing `webp` and `jpg` `srcset` variants and `sizes` hints.
- Enable lazy loading and asynchronous decoding for better page load behavior via `loading="lazy"` and `decoding="async"`.
- Use the existing 320/640/960 assets already present in `/images` for appropriate resolutions.

### Description
- Replaced the simple `<img src="/images/only-a-fan-dream-cover.png">` with a `<picture>` element containing a `source` for `webp` and an `img` fallback with `srcset`/`sizes` attributes.
- Added `decoding="async"`, `loading="lazy"`, and the same `style` (`aspect-ratio`, `object-fit`, `border-radius`) and `width`/`height` values used by other novel covers.
- Referenced the existing files `/images/only-a-fan-dream-cover-320.{jpg,webp}`, `/images/only-a-fan-dream-cover-640.{jpg,webp}`, and `/images/only-a-fan-dream-cover-960.{jpg,webp}` in the `srcset` entries.
- Modified file: `novel/index.html`.

### Testing
- Served the site locally with `python -m http.server 8000` and confirmed the page loads without errors (automated run succeeded).
- Captured a full-page screenshot using a Playwright script to verify markup rendering, and the screenshot run completed successfully.
- No unit or integration tests were applicable for this static HTML change.
- The change was committed to the repository (`git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e31d591fc83269be7cc626cac8720)